### PR TITLE
Configurable project id for the authentication emulator

### DIFF
--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -321,9 +321,7 @@ export async function createApp(
   return app;
 
   function getProjectIdByApiKey(apiKey: string): string {
-    /* unused */ apiKey;
-    // We treat any non-empty string as a valid key for the default projectId.
-    return defaultProjectId;
+    return apiKey;
   }
 
   function getProjectStateById(projectId: string): ProjectState {


### PR DESCRIPTION
### Description

When I'm developing on a Firebase project I have two separate projects for development and testing, for example "project-dev" and "project-test". The reason for this is test isolation, I don't want work from the development environment affecting the outcome of a test.

All the Firebase emulators seem to use the `projectId` that's passed into the `firebase.initializeApp(...)` method except for the authentication emulator. I noticed this when I was writing tests using Cypress and trying to create accounts for testing the login flow, because all users created would show up in the "project-dev" accounts instead of the "project-test" accounts.

Looking at the implementation I found that this POST request is made when signing up a new user containing the **key** parameter

```
http://localhost:9099/www.googleapis.com/identitytoolkit/v3/relyingparty/signupNewUser?key=fake-api-key
```

That key is passed into the authentication emulator and ignored (as far as I can see), so my proposal is to use the `key` parameter as a way to determine the project id. This is also in line how Firebase works in production according to this article https://firebase.google.com/docs/projects/api-keys.

### Scenarios Tested

I've modified my local version of the `firebase-tools` project and it seems to behave as expected, creating users into different projects.
